### PR TITLE
Deploy/Link for GooglePlayStore

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -19,7 +19,7 @@ const Footer = () => {
         </div>
       </div>
       <div className={styles.downloadButtons}>
-        <a href="" target={"_blank"}>
+        <a href="https://play.google.com/store/apps/details?id=com.wafflestudio.guam_community" target={"_blank"}>
           <img
             src="/google-play-badge.png"
             alt="구글 플레이 스토어에서 다운로드받기"


### PR DESCRIPTION
> 하단 스토어 링크 아이콘 [PR](https://github.com/wafflestudio/guam-community-web/pull/29)의 연장선상

- Google Play Store 공식 출시에 따른 앱 다운로드 링크 매핑